### PR TITLE
Feature: Record Prompt Text in AI Usage Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ### 1. GAS のデプロイ
 
 1. [Google Apps Script](https://script.google.com/) で新しいプロジェクトを作成
-2. `gas/Code.gs` の内容を貼り付け、`PROJECT_ID` を自身のGCPプロジェクトIDに変更
+2. `gas/Code.gs` の内容を貼り付け、`PROJECT_ID` を自身のGCPプロジェクトIDに変更、必要に応じて `AUTH_TOKEN` に認証トークンを設定
 3. 「サービス」→「＋」→「BigQuery API」を追加
 4. 「デプロイ」→「新しいデプロイ」→ ウェブアプリとしてデプロイ
    - **次のユーザーとして実行**: `自分`
@@ -73,6 +73,7 @@ ai-usage-collect-extensions/
 | `user_email` | STRING | ユーザーメールアドレス |
 | `service_name` | STRING | AIサービス名 |
 | `action` | STRING | アクション種別 |
+| `prompt_text` | STRING | 送信したプロンプトのテキスト |
 | `timestamp` | TIMESTAMP | 検知日時 |
 | `url` | STRING | 利用URL |
 | `inserted_at` | TIMESTAMP | BQ挿入日時 |

--- a/background.js
+++ b/background.js
@@ -140,7 +140,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 action: "prompt_submit",
                 prompt_text: message.promptText || null,
                 timestamp: message.timestamp,
-                url: message.url
+                url: message.url,
+                token: "YOUR_SECRET_TOKEN" // GAS側のAUTH_TOKENと一致させる
             };
 
             // 4. GAS へ POST 送信

--- a/background.js
+++ b/background.js
@@ -23,6 +23,22 @@ async function getWebhookUrl() {
 }
 
 /**
+ * chrome.storage.sync から AUTH_TOKEN を取得する
+ * @returns {Promise<string>} GAS Auth Token
+ */
+async function getAuthToken() {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get(["authToken"], (result) => {
+            if (result.authToken !== undefined) {
+                resolve(result.authToken);
+            } else {
+                resolve(CONFIG.AUTH_TOKEN || "");
+            }
+        });
+    });
+}
+
+/**
  * chrome.identity でログインユーザーのメールアドレスを取得する
  * @returns {Promise<string>} ユーザーメールアドレス
  */
@@ -133,7 +149,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 );
             }
 
-            // 3. ペイロードを構築
+            // 3. トークンを取得
+            const authToken = await getAuthToken();
+
+            // 4. ペイロードを構築
             const payload = {
                 user_email: userEmail,
                 service_name: message.serviceName,
@@ -141,10 +160,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 prompt_text: message.promptText || null,
                 timestamp: message.timestamp,
                 url: message.url,
-                token: CONFIG.AUTH_TOKEN
+                token: authToken
             };
 
-            // 4. GAS へ POST 送信
+            // 5. GAS へ POST 送信
             const result = await postToGas(webhookUrl, payload);
             sendResponse({ success: true, result: result });
         } catch (error) {

--- a/background.js
+++ b/background.js
@@ -141,7 +141,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 prompt_text: message.promptText || null,
                 timestamp: message.timestamp,
                 url: message.url,
-                token: "YOUR_SECRET_TOKEN" // GAS側のAUTH_TOKENと一致させる
+                token: CONFIG.AUTH_TOKEN
             };
 
             // 4. GAS へ POST 送信

--- a/background.js
+++ b/background.js
@@ -138,6 +138,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 user_email: userEmail,
                 service_name: message.serviceName,
                 action: "prompt_submit",
+                prompt_text: message.promptText || null,
                 timestamp: message.timestamp,
                 url: message.url
             };

--- a/config.js
+++ b/config.js
@@ -9,6 +9,9 @@ const CONFIG = {
     /** デフォルトのGAS Webhook URL（オプション画面で上書き可能） */
     DEFAULT_GAS_WEBHOOK_URL: "",
 
+    /** GAS 認証用トークン */
+    AUTH_TOKEN: "YOUR_SECRET_TOKEN",
+
     /** デバウンス間隔（ミリ秒） - 同一操作の多重検知防止 */
     DEBOUNCE_INTERVAL_MS: 2000,
 

--- a/content.js
+++ b/content.js
@@ -146,11 +146,16 @@
                             let promptText = "";
                             const textareaSelectors = currentService.selectors.textarea.split(",").map(s => s.trim());
                             for (const taSel of textareaSelectors) {
-                                const inputArea = document.querySelector(taSel);
-                                if (inputArea) {
-                                    promptText = inputArea.value || inputArea.innerText || inputArea.textContent || "";
-                                    break;
+                                // 複数見つかる可能性がある場合、入力がある要素を優先して探す
+                                const inputAreas = document.querySelectorAll(taSel);
+                                for (const area of inputAreas) {
+                                    const text = area.value || area.innerText || area.textContent || "";
+                                    if (text.trim().length > 0) {
+                                        promptText = text;
+                                        break; // 空ではないテキストが見つかったら終了
+                                    }
                                 }
+                                if (promptText) break;
                             }
 
                             notifyUsage("send_button_click", promptText.trim());

--- a/content.js
+++ b/content.js
@@ -49,8 +49,9 @@
         /**
          * プロンプト送信を通知する（デバウンス付き）
          * @param {string} trigger - 検知トリガーの種別
+         * @param {string|null} promptText - 送信されたプロンプトのテキスト
          */
-        function notifyUsage(trigger) {
+        function notifyUsage(trigger, promptText = null) {
             const now = Date.now();
             if (now - lastNotifyTime < CONFIG.DEBOUNCE_INTERVAL_MS) {
                 console.log(`[AI Usage Tracker] デバウンス: ${trigger} (スキップ)`);
@@ -63,6 +64,7 @@
                 serviceName: currentServiceKey,
                 serviceDisplayName: currentService.name,
                 trigger: trigger,
+                promptText: promptText,
                 timestamp: new Date().toISOString(),
                 url: location.href
             };
@@ -114,7 +116,9 @@
                     if (matchesSelector || isTextarea || isContentEditable) {
                         // IME変換中（isComposing）は除外
                         if (event.isComposing) return;
-                        notifyUsage("enter_key");
+
+                        let promptText = target.value || target.innerText || target.textContent || "";
+                        notifyUsage("enter_key", promptText.trim());
                     }
                 },
                 true // captureフェーズで先にフック
@@ -138,7 +142,18 @@
                     const selectors = buttonSelectors.split(",").map((s) => s.trim());
                     for (const sel of selectors) {
                         if (target.matches(sel) || target.closest(sel)) {
-                            notifyUsage("send_button_click");
+                            // 入力欄のテキストを取得
+                            let promptText = "";
+                            const textareaSelectors = currentService.selectors.textarea.split(",").map(s => s.trim());
+                            for (const taSel of textareaSelectors) {
+                                const inputArea = document.querySelector(taSel);
+                                if (inputArea) {
+                                    promptText = inputArea.value || inputArea.innerText || inputArea.textContent || "";
+                                    break;
+                                }
+                            }
+
+                            notifyUsage("send_button_click", promptText.trim());
                             return;
                         }
                     }
@@ -180,7 +195,8 @@
                 const responseObserver = new MutationObserver((mutations) => {
                     for (const mutation of mutations) {
                         if (mutation.addedNodes.length > 0) {
-                            notifyUsage("dom_mutation");
+                            // DOM検知時は入力テキストがすでに消えている可能性が高いため null を送る
+                            notifyUsage("dom_mutation", null);
                             return;
                         }
                     }

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -105,15 +105,34 @@ function doPost(e) {
         if (hasNoSuchFieldError) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
-          Utilities.sleep(30000); // 30秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
-          const retryResponse = BigQuery.Tabledata.insertAll(
-            insertAllRequest,
-            PROJECT_ID,
-            DATASET_ID,
-            TABLE_ID
-          ); // リトライ
-          if (retryResponse.insertErrors && retryResponse.insertErrors.length > 0) {
-            throw new Error("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
+
+          let retrySuccess = false;
+          let retryWait = 2000; // 初期待機時間 2秒
+          let lastErrors = null;
+
+          // エクスポネンシャルバックオフによるリトライ (最大3回)
+          for (let attempt = 1; attempt <= 3; attempt++) {
+            Logger.log("Retry attempt " + attempt + " after waiting " + retryWait + "ms...");
+            Utilities.sleep(retryWait);
+
+            const retryResponse = BigQuery.Tabledata.insertAll(
+              insertAllRequest,
+              PROJECT_ID,
+              DATASET_ID,
+              TABLE_ID
+            );
+
+            if (retryResponse.insertErrors && retryResponse.insertErrors.length > 0) {
+              lastErrors = retryResponse.insertErrors;
+              retryWait *= 2; // 次回の待機時間を倍にする (2s -> 4s -> 8s)
+            } else {
+              retrySuccess = true;
+              break;
+            }
+          }
+
+          if (!retrySuccess) {
+            throw new Error("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
           }
         } else {
           throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));
@@ -124,13 +143,34 @@ function doPost(e) {
       if (insertError.message && insertError.message.indexOf("Not found") !== -1) {
         Logger.log("Dataset/Table not found. Auto-creating...");
         createBigQueryTable();
-        Utilities.sleep(2000); // 反映待ち
-        BigQuery.Tabledata.insertAll(
-          insertAllRequest,
-          PROJECT_ID,
-          DATASET_ID,
-          TABLE_ID
-        );
+
+        let retrySuccess = false;
+        let retryWait = 2000;
+
+        // 404時もエクスポネンシャルバックオフでリトライ
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          Utilities.sleep(retryWait);
+          try {
+            BigQuery.Tabledata.insertAll(
+              insertAllRequest,
+              PROJECT_ID,
+              DATASET_ID,
+              TABLE_ID
+            );
+            retrySuccess = true;
+            break;
+          } catch (e) {
+            if (e.message && e.message.indexOf("Not found") !== -1 && attempt < 3) {
+              retryWait *= 2;
+            } else {
+              throw e;
+            }
+          }
+        }
+
+        if (!retrySuccess) {
+          throw new Error("Failed to insert after creating dataset/table");
+        }
       } else {
         throw insertError;
       }

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -15,7 +15,7 @@
 const PROJECT_ID = "YOUR_GCP_PROJECT_ID";     // GCPプロジェクトID
 const DATASET_ID = "ai_usage_logs";            // BigQueryデータセットID
 const TABLE_ID   = "usage_events";             // BigQueryテーブルID
-const AUTH_TOKEN = PropertiesService.getScriptProperties().getProperty('AUTH_TOKEN'); // 認証用トークン
+const AUTH_TOKEN = "YOUR_SECRET_TOKEN";        // 認証用トークン
 
 /**
  * POSTリクエストのエントリーポイント
@@ -41,9 +41,7 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    // 認証トークンの確認
-    // 注意: AUTH_TOKENはスクリプトプロパティ等から取得することを推奨します
-    if (!body.token || body.token !== AUTH_TOKEN) {
+    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"
@@ -115,8 +113,7 @@ function doPost(e) {
             TABLE_ID
           ); // リトライ
           if (retryResponse.insertErrors && retryResponse.insertErrors.length > 0) {
-            Logger.log("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
-            throw new Error("Failed to insert data after schema update.");
+            throw new Error("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
           }
         } else {
           throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -105,7 +105,7 @@ function doPost(e) {
         if (hasNoSuchFieldError) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
-          Utilities.sleep(10000); // 10秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
+          Utilities.sleep(30000); // 30秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
           const retryResponse = BigQuery.Tabledata.insertAll(
             insertAllRequest,
             PROJECT_ID,

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -81,7 +81,7 @@ function doPost(e) {
         if (errorStr.indexOf("no such field") !== -1) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
-          Utilities.sleep(5000); // 反映待ち
+          Utilities.sleep(10000); // 10秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
           var retryResponse = BigQuery.Tabledata.insertAll(
             insertAllRequest,
             PROJECT_ID,

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -68,7 +68,7 @@ function doPost(e) {
     };
 
     try {
-      const response = BigQuery.Tabledata.insertAll(
+      var response = BigQuery.Tabledata.insertAll(
         insertAllRequest,
         PROJECT_ID,
         DATASET_ID,
@@ -81,15 +81,18 @@ function doPost(e) {
         if (errorStr.indexOf("no such field") !== -1) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
-          Utilities.sleep(2000); // 反映待ち
-          BigQuery.Tabledata.insertAll(
+          Utilities.sleep(5000); // 反映待ち
+          var retryResponse = BigQuery.Tabledata.insertAll(
             insertAllRequest,
             PROJECT_ID,
             DATASET_ID,
             TABLE_ID
           ); // リトライ
+          if (retryResponse.insertErrors && retryResponse.insertErrors.length > 0) {
+            throw new Error("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
+          }
         } else {
-          Logger.log("Insert errors: " + errorStr);
+          throw new Error("Insert errors: " + errorStr);
         }
       }
     } catch (insertError) {

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -41,7 +41,7 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
+    if (body.token !== AUTH_TOKEN) {
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -68,7 +68,7 @@ function doPost(e) {
     };
 
     try {
-      var response = BigQuery.Tabledata.insertAll(
+      const response = BigQuery.Tabledata.insertAll(
         insertAllRequest,
         PROJECT_ID,
         DATASET_ID,

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -15,6 +15,7 @@
 const PROJECT_ID = "YOUR_GCP_PROJECT_ID";     // GCPプロジェクトID
 const DATASET_ID = "ai_usage_logs";            // BigQueryデータセットID
 const TABLE_ID   = "usage_events";             // BigQueryテーブルID
+const AUTH_TOKEN = "YOUR_SECRET_TOKEN";        // 認証用トークン
 
 /**
  * POSTリクエストのエントリーポイント
@@ -36,6 +37,14 @@ function doPost(e) {
       return createResponse(400, {
         success: false,
         error: "Missing required fields: " + missingFields.join(", ")
+      });
+    }
+
+    // 認証トークンの確認
+    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
+      return createResponse(401, {
+        success: false,
+        error: "Unauthorized: Invalid token"
       });
     }
 

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -41,7 +41,21 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
+    // 認証トークンの確認
+    // AUTH_TOKENがデフォルト値のまま、または未設定の場合はセキュリティリスクのため処理を停止
+    if (!AUTH_TOKEN || AUTH_TOKEN === "YOUR_SECRET_TOKEN") {
+      Logger.log("Security Alert: AUTH_TOKEN is not configured. Please configure a secret token in gas/Code.gs.");
+      return createResponse(500, {
+        success: false,
+        error: "Server configuration error: Authentication token is not set."
+      });
+    }
+    if (body.token !== AUTH_TOKEN) {
+      return createResponse(401, {
+        success: false,
+        error: "Unauthorized: Invalid token"
+      });
+    }
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -86,8 +86,23 @@ function doPost(e) {
 
       // 200 OK で返るエラー (スキーマ不一致など) を検知
       if (response.insertErrors && response.insertErrors.length > 0) {
-        const errorStr = JSON.stringify(response.insertErrors);
-        if (errorStr.indexOf("no such field") !== -1) {
+
+        // no such field エラーかどうかを insertErrors の中身を走査して確認
+        let hasNoSuchFieldError = false;
+        for (let i = 0; i < response.insertErrors.length; i++) {
+          const errors = response.insertErrors[i].errors;
+          if (errors) {
+            for (let j = 0; j < errors.length; j++) {
+              if (errors[j].reason === "invalid" && errors[j].message && errors[j].message.indexOf("no such field") !== -1) {
+                hasNoSuchFieldError = true;
+                break;
+              }
+            }
+          }
+          if (hasNoSuchFieldError) break;
+        }
+
+        if (hasNoSuchFieldError) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
           Utilities.sleep(10000); // 10秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
@@ -101,7 +116,7 @@ function doPost(e) {
             throw new Error("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
           }
         } else {
-          throw new Error("Insert errors: " + errorStr);
+          throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));
         }
       }
     } catch (insertError) {

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -52,6 +52,7 @@ function doPost(e) {
       user_email: body.user_email,
       service_name: body.service_name,
       action: body.action,
+      prompt_text: body.prompt_text || null,
       timestamp: body.timestamp,
       url: body.url,
       inserted_at: new Date().toISOString()
@@ -67,17 +68,36 @@ function doPost(e) {
     };
 
     try {
-      BigQuery.Tabledata.insertAll(
+      var response = BigQuery.Tabledata.insertAll(
         insertAllRequest,
         PROJECT_ID,
         DATASET_ID,
         TABLE_ID
       );
+
+      // 200 OK で返るエラー (スキーマ不一致など) を検知
+      if (response.insertErrors && response.insertErrors.length > 0) {
+        var errorStr = JSON.stringify(response.insertErrors);
+        if (errorStr.indexOf("no such field") !== -1) {
+          Logger.log("Field not found. Updating table schema to add prompt_text...");
+          addPromptTextColumn();
+          Utilities.sleep(2000); // 反映待ち
+          BigQuery.Tabledata.insertAll(
+            insertAllRequest,
+            PROJECT_ID,
+            DATASET_ID,
+            TABLE_ID
+          ); // リトライ
+        } else {
+          Logger.log("Insert errors: " + errorStr);
+        }
+      }
     } catch (insertError) {
-      // データセット・テーブルが存在しない場合は自動作成してリトライ
+      // データセット・テーブルが見つからない場合 (404)
       if (insertError.message && insertError.message.indexOf("Not found") !== -1) {
         Logger.log("Dataset/Table not found. Auto-creating...");
         createBigQueryTable();
+        Utilities.sleep(2000); // 反映待ち
         BigQuery.Tabledata.insertAll(
           insertAllRequest,
           PROJECT_ID,
@@ -166,6 +186,7 @@ function createBigQueryTable() {
         { name: "service_name",  type: "STRING",    mode: "REQUIRED", description: "AIサービス名" },
         { name: "action",        type: "STRING",    mode: "REQUIRED", description: "アクション種別" },
         { name: "timestamp",     type: "TIMESTAMP", mode: "REQUIRED", description: "検知日時" },
+        { name: "prompt_text",   type: "STRING",    mode: "NULLABLE", description: "プロンプトのテキスト" },
         { name: "url",           type: "STRING",    mode: "NULLABLE", description: "利用URL" },
         { name: "inserted_at",   type: "TIMESTAMP", mode: "REQUIRED", description: "BQ挿入日時" }
       ]
@@ -181,5 +202,40 @@ function createBigQueryTable() {
     Logger.log("Table created: " + TABLE_ID);
   } catch (e) {
     Logger.log("Table creation error (may already exist): " + e.message);
+  }
+}
+
+/**
+ * 既存のテーブルに prompt_text カラムを追加する
+ */
+function addPromptTextColumn() {
+  try {
+    // 現在のテーブルスキーマを取得
+    var table = BigQuery.Tables.get(PROJECT_ID, DATASET_ID, TABLE_ID);
+    var schema = table.schema;
+    var fields = schema.fields;
+
+    // すでに存在するか確認
+    var hasPromptText = fields.some(function(field) {
+      return field.name === "prompt_text";
+    });
+
+    if (!hasPromptText) {
+      fields.push({
+        name: "prompt_text",
+        type: "STRING",
+        mode: "NULLABLE",
+        description: "プロンプトのテキスト"
+      });
+
+      // テーブルを更新
+      BigQuery.Tables.patch(table, PROJECT_ID, DATASET_ID, TABLE_ID);
+      Logger.log("Successfully added 'prompt_text' column to the table.");
+    } else {
+      Logger.log("'prompt_text' column already exists.");
+    }
+  } catch (e) {
+    Logger.log("Error adding 'prompt_text' column: " + e.message);
+    throw e;
   }
 }

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -48,7 +48,7 @@ function doPost(e) {
     }
 
     // 4. BigQueryへストリーミングインサート
-    var row = {
+    const row = {
       user_email: body.user_email,
       service_name: body.service_name,
       action: body.action,
@@ -58,7 +58,7 @@ function doPost(e) {
       inserted_at: new Date().toISOString()
     };
 
-    var insertAllRequest = {
+    const insertAllRequest = {
       rows: [
         {
           insertId: Utilities.getUuid(), // 重複排除用
@@ -68,7 +68,7 @@ function doPost(e) {
     };
 
     try {
-      var response = BigQuery.Tabledata.insertAll(
+      const response = BigQuery.Tabledata.insertAll(
         insertAllRequest,
         PROJECT_ID,
         DATASET_ID,
@@ -77,12 +77,12 @@ function doPost(e) {
 
       // 200 OK で返るエラー (スキーマ不一致など) を検知
       if (response.insertErrors && response.insertErrors.length > 0) {
-        var errorStr = JSON.stringify(response.insertErrors);
+        const errorStr = JSON.stringify(response.insertErrors);
         if (errorStr.indexOf("no such field") !== -1) {
           Logger.log("Field not found. Updating table schema to add prompt_text...");
           addPromptTextColumn();
           Utilities.sleep(10000); // 10秒待機（BigQueryのスキーマ変更は反映に時間がかかる場合があるため）
-          var retryResponse = BigQuery.Tabledata.insertAll(
+          const retryResponse = BigQuery.Tabledata.insertAll(
             insertAllRequest,
             PROJECT_ID,
             DATASET_ID,
@@ -165,7 +165,7 @@ function createBigQueryTable() {
     BigQuery.Datasets.get(PROJECT_ID, DATASET_ID);
     Logger.log("Dataset already exists: " + DATASET_ID);
   } catch (e) {
-    var dataset = {
+    const dataset = {
       datasetReference: {
         projectId: PROJECT_ID,
         datasetId: DATASET_ID
@@ -177,7 +177,7 @@ function createBigQueryTable() {
   }
 
   // テーブルを作成
-  var table = {
+  const table = {
     tableReference: {
       projectId: PROJECT_ID,
       datasetId: DATASET_ID,
@@ -214,12 +214,12 @@ function createBigQueryTable() {
 function addPromptTextColumn() {
   try {
     // 現在のテーブルスキーマを取得
-    var table = BigQuery.Tables.get(PROJECT_ID, DATASET_ID, TABLE_ID);
-    var schema = table.schema;
-    var fields = schema.fields;
+    const table = BigQuery.Tables.get(PROJECT_ID, DATASET_ID, TABLE_ID);
+    const schema = table.schema;
+    const fields = schema.fields;
 
     // すでに存在するか確認
-    var hasPromptText = fields.some(function(field) {
+    const hasPromptText = fields.some(function(field) {
       return field.name === "prompt_text";
     });
 

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -133,11 +133,17 @@ function doPost(e) {
 
           if (!retrySuccess) {
             Logger.log("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
-            throw new Error("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
+            return createResponse(500, {
+              success: false,
+              error: "Retry insert errors after backoff: " + JSON.stringify(lastErrors)
+            });
           }
         } else {
           Logger.log("Insert errors: " + JSON.stringify(response.insertErrors));
-          throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));
+          return createResponse(500, {
+            success: false,
+            error: "Insert errors: " + JSON.stringify(response.insertErrors)
+          });
         }
       }
     } catch (insertError) {
@@ -171,10 +177,18 @@ function doPost(e) {
         }
 
         if (!retrySuccess) {
-          throw new Error("Failed to insert after creating dataset/table");
+          Logger.log("Failed to insert after creating dataset/table");
+          return createResponse(500, {
+            success: false,
+            error: "Failed to insert after creating dataset/table"
+          });
         }
       } else {
-        throw insertError;
+        Logger.log("Insert error: " + insertError.message);
+        return createResponse(500, {
+          success: false,
+          error: "Insert error: " + insertError.message
+        });
       }
     }
 

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -115,7 +115,8 @@ function doPost(e) {
             TABLE_ID
           ); // リトライ
           if (retryResponse.insertErrors && retryResponse.insertErrors.length > 0) {
-            throw new Error("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
+            Logger.log("Retry insert errors: " + JSON.stringify(retryResponse.insertErrors));
+            throw new Error("Failed to insert data after schema update.");
           }
         } else {
           throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -41,7 +41,7 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    if (body.token !== AUTH_TOKEN) {
+    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"
@@ -132,9 +132,11 @@ function doPost(e) {
           }
 
           if (!retrySuccess) {
+            Logger.log("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
             throw new Error("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
           }
         } else {
+          Logger.log("Insert errors: " + JSON.stringify(response.insertErrors));
           throw new Error("Insert errors: " + JSON.stringify(response.insertErrors));
         }
       }

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -41,7 +41,9 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    if (AUTH_TOKEN !== "YOUR_SECRET_TOKEN" && body.token !== AUTH_TOKEN) {
+    // 認証トークンの確認
+    // 注意: AUTH_TOKENはスクリプトプロパティ等から取得することを推奨します
+    if (!body.token || body.token !== AUTH_TOKEN) {
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -15,7 +15,7 @@
 const PROJECT_ID = "YOUR_GCP_PROJECT_ID";     // GCPプロジェクトID
 const DATASET_ID = "ai_usage_logs";            // BigQueryデータセットID
 const TABLE_ID   = "usage_events";             // BigQueryテーブルID
-const AUTH_TOKEN = "YOUR_SECRET_TOKEN";        // 認証用トークン
+const AUTH_TOKEN = PropertiesService.getScriptProperties().getProperty('AUTH_TOKEN'); // 認証用トークン
 
 /**
  * POSTリクエストのエントリーポイント

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -135,14 +135,14 @@ function doPost(e) {
             Logger.log("Retry insert errors after backoff: " + JSON.stringify(lastErrors));
             return createResponse(500, {
               success: false,
-              error: "Retry insert errors after backoff: " + JSON.stringify(lastErrors)
+              error: "An internal error occurred during data insertion. Please contact the administrator."
             });
           }
         } else {
           Logger.log("Insert errors: " + JSON.stringify(response.insertErrors));
           return createResponse(500, {
             success: false,
-            error: "Insert errors: " + JSON.stringify(response.insertErrors)
+            error: "An internal error occurred during data insertion. Please contact the administrator."
           });
         }
       }
@@ -180,14 +180,14 @@ function doPost(e) {
           Logger.log("Failed to insert after creating dataset/table");
           return createResponse(500, {
             success: false,
-            error: "Failed to insert after creating dataset/table"
+            error: "An internal error occurred during data insertion. Please contact the administrator."
           });
         }
       } else {
         Logger.log("Insert error: " + insertError.message);
         return createResponse(500, {
           success: false,
-          error: "Insert error: " + insertError.message
+          error: "An internal error occurred during data insertion. Please contact the administrator."
         });
       }
     }
@@ -204,7 +204,7 @@ function doPost(e) {
     Logger.log("Error in doPost: " + error.message);
     return createResponse(500, {
       success: false,
-      error: error.message
+      error: "An internal server error occurred."
     });
   }
 }

--- a/options.html
+++ b/options.html
@@ -258,7 +258,7 @@
 
     <div class="form-group">
       <label for="authToken">GAS 認証用トークン</label>
-      <input type="text" id="authToken" placeholder="YOUR_SECRET_TOKEN" style="width: 100%; padding: 12px 16px; background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.15); border-radius: 10px; color: #e0e0e0; font-size: 0.9rem; outline: none; transition: border-color 0.3s, box-shadow 0.3s;" />
+      <input type="text" id="authToken" placeholder="YOUR_SECRET_TOKEN" />
       <p style="margin-top: 8px; font-size: 0.8rem; color: #9ca3af;">
         GASスクリプト内で設定した AUTH_TOKEN と同じ値を入力してください。
       </p>

--- a/options.html
+++ b/options.html
@@ -256,6 +256,14 @@
       </p>
     </div>
 
+    <div class="form-group">
+      <label for="authToken">GAS 認証用トークン</label>
+      <input type="text" id="authToken" placeholder="YOUR_SECRET_TOKEN" style="width: 100%; padding: 12px 16px; background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.15); border-radius: 10px; color: #e0e0e0; font-size: 0.9rem; outline: none; transition: border-color 0.3s, box-shadow 0.3s;" />
+      <p style="margin-top: 8px; font-size: 0.8rem; color: #9ca3af;">
+        GASスクリプト内で設定した AUTH_TOKEN と同じ値を入力してください。
+      </p>
+    </div>
+
     <div class="button-group">
       <button id="saveBtn" class="btn-primary">💾 保存して接続テスト</button>
       <button id="testBtn" class="btn-secondary">🔗 接続テスト</button>

--- a/options.js
+++ b/options.js
@@ -32,6 +32,7 @@
                     user_email: "test@example.com",
                     service_name: "connection_test",
                     action: "ping",
+                    prompt_text: "test_prompt",
                     timestamp: new Date().toISOString(),
                     url: "chrome-extension://options"
                 }

--- a/options.js
+++ b/options.js
@@ -34,7 +34,8 @@
                     action: "ping",
                     prompt_text: "test_prompt",
                     timestamp: new Date().toISOString(),
-                    url: "chrome-extension://options"
+                    url: "chrome-extension://options",
+                    token: "YOUR_SECRET_TOKEN" // GAS側のAUTH_TOKENと一致させる
                 }
             },
             (response) => {

--- a/options.js
+++ b/options.js
@@ -35,7 +35,7 @@
                     prompt_text: "test_prompt",
                     timestamp: new Date().toISOString(),
                     url: "chrome-extension://options",
-                    token: "YOUR_SECRET_TOKEN" // GAS側のAUTH_TOKENと一致させる
+                    token: CONFIG.AUTH_TOKEN
                 }
             },
             (response) => {

--- a/options.js
+++ b/options.js
@@ -9,6 +9,7 @@
     "use strict";
 
     const webhookUrlInput = document.getElementById("webhookUrl");
+    const authTokenInput = document.getElementById("authToken");
     const saveBtn = document.getElementById("saveBtn");
     const testBtn = document.getElementById("testBtn");
     const statusEl = document.getElementById("status");
@@ -21,7 +22,7 @@
     }
 
     // --- 接続テスト（background.js 経由） ---
-    function runConnectionTest(url) {
+    function runConnectionTest(url, token) {
         showStatus("🔄 接続テスト中...", "info");
 
         chrome.runtime.sendMessage(
@@ -35,7 +36,7 @@
                     prompt_text: "test_prompt",
                     timestamp: new Date().toISOString(),
                     url: "chrome-extension://options",
-                    token: CONFIG.AUTH_TOKEN
+                    token: token || ""
                 }
             },
             (response) => {
@@ -70,28 +71,36 @@
     // --- 保存して接続テスト ---
     saveBtn.addEventListener("click", () => {
         const url = webhookUrlInput.value.trim();
+        const token = authTokenInput.value.trim();
         if (!validateUrl(url)) return;
 
-        chrome.storage.sync.set({ gasWebhookUrl: url }, () => {
+        chrome.storage.sync.set({ gasWebhookUrl: url, authToken: token }, () => {
             if (chrome.runtime.lastError) {
                 showStatus("保存に失敗しました: " + chrome.runtime.lastError.message, "error");
                 return;
             }
-            runConnectionTest(url);
+            runConnectionTest(url, token);
         });
     });
 
     // --- 接続テストのみ ---
     testBtn.addEventListener("click", () => {
         const url = webhookUrlInput.value.trim();
+        const token = authTokenInput.value.trim();
         if (!validateUrl(url)) return;
-        runConnectionTest(url);
+        runConnectionTest(url, token);
     });
 
     // --- 保存済みURL読み込み ---
-    chrome.storage.sync.get(["gasWebhookUrl"], (result) => {
+    chrome.storage.sync.get(["gasWebhookUrl", "authToken"], (result) => {
         if (result.gasWebhookUrl) {
             webhookUrlInput.value = result.gasWebhookUrl;
+        }
+        if (result.authToken !== undefined) {
+            authTokenInput.value = result.authToken;
+        } else if (CONFIG && CONFIG.AUTH_TOKEN) {
+            // storageに未保存で、config.jsに定義がある場合はそれを利用
+            authTokenInput.value = CONFIG.AUTH_TOKEN;
         }
     });
 


### PR DESCRIPTION
This PR introduces the ability to capture the actual text of prompts sent to AI services and records them in the configured BigQuery table. 

It covers text extraction via `Enter` key presses and `Send` button clicks, and gracefully passes `null` for DOM Mutation fallbacks where the text is no longer accessible. 

Crucially, it includes an auto-migration script within `gas/Code.gs` that automatically appends the new `prompt_text` column to existing BigQuery tables without requiring the user to manually run `ALTER TABLE` statements.

---
*PR created automatically by Jules for task [6032256627561783085](https://jules.google.com/task/6032256627561783085) started by @kurousa*