### PR TITLE
🔒 [security fix] Add authorization checks for background messages

### DIFF
--- a/background.js
+++ b/background.js
@@ -86,8 +86,21 @@ async function postToGas(url, data, retryCount = CONFIG.MAX_RETRY_COUNT) {
 
 // --- メッセージリスナー ---
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    // 許可された送信元かチェック（自分の拡張機能以外からのメッセージを無視）
+    if (sender.id !== chrome.runtime.id) {
+        console.warn("[AI Usage Tracker] 拒否されたメッセージ送信元:", sender.id);
+        return false;
+    }
+
     // --- 接続テスト（オプション画面から） ---
     if (message.type === "CONNECTION_TEST") {
+        // オプション画面からのリクエストであることをURLで追加検証
+        const optionsUrl = `chrome-extension://${chrome.runtime.id}/options.html`;
+        if (!sender.url || !sender.url.startsWith(optionsUrl)) {
+            console.warn("[AI Usage Tracker] CONNECTION_TEST が許可されていないURLから送信されました:", sender.url);
+            return false;
+        }
+
         (async () => {
             try {
                 const result = await postToGas(message.url, message.payload, 0);

--- a/background.js
+++ b/background.js
@@ -95,8 +95,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // --- 接続テスト（オプション画面から） ---
     if (message.type === "CONNECTION_TEST") {
         // オプション画面からのリクエストであることをURLで追加検証
-        const optionsUrl = `chrome-extension://${chrome.runtime.id}/options.html`;
-        if (!sender.url || !sender.url.startsWith(optionsUrl)) {
+        const optionsUrl = chrome.runtime.getURL("options.html");
+        if (sender.url !== optionsUrl) {
             console.warn("[AI Usage Tracker] CONNECTION_TEST が許可されていないURLから送信されました:", sender.url);
             return false;
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Missing Authorization Check for Connections in `background.js`.

⚠️ **Risk:** The potential impact if left unfixed
An external extension or a malicious website (if permissions allow) could potentially send messages to the background script. Specifically, the `CONNECTION_TEST` action allowed arbitrary URL fetching, which could be abused for Server-Side Request Forgery (SSRF) or unauthorized data exfiltration if an attacker could trigger it.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix adds a global check at the start of the `chrome.runtime.onMessage` listener to ensure `sender.id` matches the extension's own ID. For the sensitive `CONNECTION_TEST` message, it further validates that the request originates from the extension's `options.html` page by checking `sender.url`. This ensures that only trusted parts of the extension can trigger these actions.

---
*PR created automatically by Jules for task [7680671685363945250](https://jules.google.com/task/7680671685363945250) started by @kurousa*