### PR TITLE
🧹 Fix duplicated unauthorized error check in gas/Code.gs

### DIFF
--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -41,7 +41,6 @@ function doPost(e) {
     }
 
     // 認証トークンの確認
-    // 認証トークンの確認
     // AUTH_TOKENがデフォルト値のまま、または未設定の場合はセキュリティリスクのため処理を停止
     if (!AUTH_TOKEN || AUTH_TOKEN === "YOUR_SECRET_TOKEN") {
       Logger.log("Security Alert: AUTH_TOKEN is not configured. Please configure a secret token in gas/Code.gs.");
@@ -51,11 +50,6 @@ function doPost(e) {
       });
     }
     if (body.token !== AUTH_TOKEN) {
-      return createResponse(401, {
-        success: false,
-        error: "Unauthorized: Invalid token"
-      });
-    }
       return createResponse(401, {
         success: false,
         error: "Unauthorized: Invalid token"


### PR DESCRIPTION
This change fixes a code health issue in `gas/Code.gs` where an unauthorized error check was duplicated, leading to redundant code and potentially broken syntax due to a stray closing brace. It also cleans up a duplicated comment line. These changes improve the maintainability and readability of the GAS webhook implementation.

---
*PR created automatically by Jules for task [18442125606416453334](https://jules.google.com/task/18442125606416453334) started by @kurousa*